### PR TITLE
Build for `osx-arm64`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,8 @@ requirements:
 test:
   imports:
     - astor
+  requires:
+    - pip
   commands:
     - pip check
 


### PR DESCRIPTION
This is required for building `tensorflow` on `osx-arm64`.

(P.S.: The recipe is the same except for minor changes to make the linter happy, so I did not upgrade the build number).